### PR TITLE
Resolve config not found error

### DIFF
--- a/src/Pax8ServiceProvider.php
+++ b/src/Pax8ServiceProvider.php
@@ -14,7 +14,7 @@ class Pax8ServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__.'/config/pax8.php', 'pax8'
+            __DIR__.'/Config/pax8.php', 'pax8'
         );    }
 
     /**
@@ -25,6 +25,6 @@ class Pax8ServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__.'/config/pax8.php' => config_path('pax8.php'),
+            __DIR__.'/Config/pax8.php' => config_path('pax8.php'),
         ]);    }
 }


### PR DESCRIPTION
Noticed the config directory begins with a capital C.

When registering the provider or publishing the config, it was producing an error previously.

This seems to resolve the issue.