### PR TITLE
Added order create method

### DIFF
--- a/src/Requests/OrderRequest.php
+++ b/src/Requests/OrderRequest.php
@@ -44,4 +44,23 @@ class OrderRequest extends AbstractRequest
         else
             return null;
     }
+
+    /**
+     * Creates a new Order.
+     *
+     * Returns null if the order contains invalid data
+     *
+     * @param Order $order
+     * @return Order|null
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function create(Order $order): ?Order
+    {
+        $response = $this->postRequest('/v1/orders', $order->createOrder() );
+
+        if ($response->getStatusCode() == 200)
+            return Order::parse(json_decode( $response->getBody() ) );
+        else
+            return null;
+    }
 }

--- a/src/Responses/Order.php
+++ b/src/Responses/Order.php
@@ -19,6 +19,14 @@ class Order extends AbstractResponse
 
     protected Collection $lineItems;
 
+    public function createOrder(): array
+    {
+        return [
+            'companyId' => $this->getCompanyId(),
+            'lineItems' => $this->getLineItems()
+        ];
+    }
+
     /**
      * @param string $companyId
      * @return Order
@@ -118,7 +126,8 @@ class Order extends AbstractResponse
         $this->lineItems = new Collection();
 
         foreach( $lineItems as $lineItem )
-            $this->lineItems->add( new OrderLine( $lineItem ) );
+            $lineItem = OrderLine::parse( (object) $lineItem );
+            $this->lineItems->add($lineItem);
 
         return $this;
     }


### PR DESCRIPTION
Hi,

I was looking at creating a API client for Pax8 and have noticed you have created one within the past couple days :-)

I've added the option to create an order via the pax8 API.

Wasn't sure what the original intention was with passing the line item into the non existent constructor as i assume the user is intended to pass in an array of arrays for the line items. Hopefully this will suffice.

Regards,

Dan